### PR TITLE
修复校验部分方法在其他模式下不存在

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "v-json-edit",
   "description": "vue json editor components",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "src/index.js",
   "author": "Brian",
   "license": "MIT",

--- a/src/Json-edit.vue
+++ b/src/Json-edit.vue
@@ -112,11 +112,14 @@ export default {
       this.editor = new JsonEditor(el, options, this.json)
     },
     expandedAll () {
+      const methodsLists = ['expandAll', 'collapseAll']
+      // mehods is exists?
+      const methodsExist = methodsLists.every(v => v in this.editor)
       const mode = this.editor.getMode()
-      if (this.expand && this.expandModes.includes(mode)) {
-        this.editor.expandAll()
-      } else {
-        this.editor.collapseAll()
+      // is expand all?
+      const isExpand = this.expand && this.expandModes.includes(mode)
+      if (methodsExist) {
+        isExpand ? this.editor.expandAll() : this.editor.collapseAll()
       }
     }
   },


### PR DESCRIPTION
修复部分方法在其他模式下不存在：
* 增加对`this.editor`的方法存在性校验